### PR TITLE
Make env files compatible with dotenv and `docker run --env-file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ If the file contains lines of the form:
 ```
 X=yyyy
 ```
-then calling `eval` on the output will put those
+then exporting the output will put those
 variables into the current environment.  i.e.
 
 ```
-export $(aws-secrets-get quizzo | xargs)
+export `aws-secrets-get quizzo`
 ```
 
 *`aws-secrets-run-in-env`* is a short script that does the above and

--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ The last one can be run by:
   - users in the `quizzo-manage-secrets` group
   - programs on ec2 instances which have been started with the `quizzo-secrets` IAM profile
 
-To start an instance with the quizzo-secrets IAM profile from the CLI:
+To start an EC2 instance with the quizzo-secrets IAM profile from the CLI:
 
   `aws ec2 run-instances ...--iam-instance-profile Name=quizzo-secrets`
+
+To start an ECS cluster with the quizzo IAM profile, select quizzo-secrets-instances from the
+Container Instance IAM Role selection on the Create Cluster screen.
 
 Description
 ===========

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ aws-secrets-init-resources quizzo
 
 Make some secrets, send them to the cloud:
 ```
-echo "export SECRET=xyzzy" > quizzo-env
+echo "SECRET=xyzzy" > quizzo-env
 aws-secrets-send quizzo quizzo-env
 ```
 
@@ -74,13 +74,13 @@ and decrypts the file and prints it to stdout.
 If the file contains lines of the form:
 
 ```
-export X=yyyy
+X=yyyy
 ```
 then calling `eval` on the output will put those
 variables into the current environment.  i.e.
 
 ```
-eval `aws-secrets-get quizzo`
+export $(aws-secrets-get quizzo | xargs)
 ```
 
 *`aws-secrets-run-in-env`* is a short script that does the above and

--- a/bin/aws-secrets-init-resources
+++ b/bin/aws-secrets-init-resources
@@ -179,7 +179,7 @@ echo "aws iam add-user-to-group --group-name $group --user-name some_user"
 echo "aws iam get-group --group-name $group"
 echo
 echo "# Create a file with an environment containing secret keys:"
-echo "echo 'export foo=bar$RANDOM' > aws-secrets"
+echo "echo 'foo=bar$RANDOM' > aws-secrets"
 echo
 echo "# Encrypt and send it to s3 :"
 echo "aws-secrets-send $app aws-secrets"

--- a/bin/aws-secrets-init-resources
+++ b/bin/aws-secrets-init-resources
@@ -187,14 +187,18 @@ echo
 echo "# Retrieve it:"
 echo "aws-secrets-get $app"
 echo
-echo "# Start an instance that can access the secrets:"
+echo "# Start an EC2 Instance"
+echo "## Start an instance that can access the secrets:"
 echo "aws ec2 run-instances --image-id ami-2d39803a --instance-type t2.nano --key-name some_aws_key \
 --iam-instance-profile Name=$instanceprofile"
 echo
-echo "# View AWS credentials on the instance : "
+echo "## View AWS credentials on the instance : "
 echo "ssh ...instance ip..."
 echo "curl -L http://169.254.169.254/latest/meta-data/iam/security-credentials/$instancerole"
 echo
-echo "# Copy aws-secrets-get to your instance and run it there to retrieve the secrets"
+echo "## Copy aws-secrets-get to your instance and run it there to retrieve the secrets"
 echo "scp aws-secrets-send ..instance ip.."
+echo
+echo "# Start an ECS Cluster"
+echo "## Create your cluster using the $instancerole IAM role on the container instance"
 

--- a/bin/aws-secrets-run-in-env
+++ b/bin/aws-secrets-run-in-env
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-app=shift
+app=$1
+shift
 
-eval `aws-secrets-get $app`
+export $(aws-secrets-get $app | xargs)
 
 exec "$@"
-

--- a/bin/aws-secrets-run-in-env
+++ b/bin/aws-secrets-run-in-env
@@ -3,6 +3,6 @@
 app=$1
 shift
 
-export $(aws-secrets-get $app | xargs)
+export `aws-secrets-get $app`
 
 exec "$@"


### PR DESCRIPTION
So not every line has to have `export` and you can use the file directly on your local machine.