### PR TITLE
Allow the bucket region to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Notes
 
 - These scripts depend on having the AWS CLI installed.  (See references below)
 
-- It may be necessary to explicitly set the region (e.g. using the AWS_DEFAULT_REGION environment variable).
+- Changing AWS_DEFAULT_REGION (or the aws-cli configuration) will effect the region used for API calls.
+
+- Changing AWS_SECRETS_BUCKET_REGION will specify the region in which the S3 bucket is created.
 
 References
 ==========

--- a/bin/aws-secrets-init-resources
+++ b/bin/aws-secrets-init-resources
@@ -41,7 +41,11 @@ bucket=$app-secrets
 found=`aws s3api list-buckets --query "Buckets[?Name == '$bucket'] | [0].Name" --output text`
 if [ "$found" == "None" ]; then
     echo "Creating bucket $bucket"
-    made=`aws s3api create-bucket --bucket $bucket --acl private --output text`
+    if [ ! -z "$AWS_SECRETS_BUCKET_REGION" ]; then
+        BUCKET_CONSTRAINT="--create-bucket-configuration LocationConstraint=$AWS_SECRETS_BUCKET_REGION"
+        BUCKET_REGION="--region $AWS_SECRETS_BUCKET_REGION"
+    fi
+    made=`aws s3api create-bucket --bucket $bucket --acl private $BUCKET_REGION $BUCKET_CONSTRAINT --output text`
 else
     echo "Found existing bucket $bucket"
 fi


### PR DESCRIPTION
AWS S3 has separate ways of specifying the region to be
used for all API calls, and the region in which a bucket should
be created.  This change provides a way to specify the latter.

Fixes #15